### PR TITLE
corrige le parametre de compression png de 9 a 5

### DIFF
--- a/launch/openni2/wm_openni2.launch
+++ b/launch/openni2/wm_openni2.launch
@@ -52,7 +52,7 @@
   <arg name="hw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <arg name="sw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <rosparam>
-    head_xtion//depth/image_raw/compressedDepth/png_level: 5
+    head_xtion/depth/image_raw/compressedDepth/png_level: 5
   </rosparam>
 
   <!-- Disable bond topics by default -->

--- a/launch/openni2/wm_openni2.launch
+++ b/launch/openni2/wm_openni2.launch
@@ -51,6 +51,9 @@
   <arg name="sw_registered_processing"        default="false" if="$(arg depth_registration)" />
   <arg name="hw_registered_processing"        default="false" unless="$(arg depth_registration)" />
   <arg name="sw_registered_processing"        default="false" unless="$(arg depth_registration)" />
+  <rosparam>
+    head_xtion//depth/image_raw/compressedDepth/png_level: 5
+  </rosparam>
 
   <!-- Disable bond topics by default -->
   <arg name="respawn" default="false" />


### PR DESCRIPTION
la compression png de niveau 9 est bien trop lente (1 sec/img). 5 est plus mieux (15 img/sec)